### PR TITLE
Update to add 'new' statement before using class Buffer on line 1443 …

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -1440,7 +1440,7 @@ if(has_buf) {
 	};
 	var corpus = "foo bar baz\u00e2\u0098\u0083\u00f0\u009f\u008d\u00a3";
 	if(utf8read(corpus) == utf8readb(corpus)) utf8read = utf8readb;
-	var utf8readc = function utf8readc(data) { return Buffer(data, 'binary').toString('utf8'); };
+	var utf8readc = function utf8readc(data) { return new Buffer(data, 'binary').toString('utf8'); };
 	if(utf8read(corpus) == utf8readc(corpus)) utf8read = utf8readc;
 }
 


### PR DESCRIPTION
…to fix deprecated warning of using with node 7 - https://github.com/SheetJS/js-xlsx/issues/490